### PR TITLE
Add ability to pass in Jade options

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ Type: `Object`
 Default value: `{}`  
 *Locals for template*
 
+##### options.jadeOptions
+Type: `Object`
+Default value: `{}`<br>
+[See the Jade docs](http://jade-lang.com/api/)
+
+
 ## CLI interface
 
 ### Installation

--- a/lib-phantom/index.js
+++ b/lib-phantom/index.js
@@ -11,6 +11,7 @@ var args = [
 , 'paperFormat'
 , 'paperOrientation'
 , 'paperBorder'
+, 'footerAdditionalHTML'
 , 'renderDelay'
 ].reduce(function(args, name, i) {
   args[name] = system.args[i+1];
@@ -34,7 +35,14 @@ page.open(args.in, function(status) {
   page.paperSize = {
     format: args.paperFormat
   , orientation: args.paperOrientation
-  , border: args.paperBorder
+  , border: JSON.parse(args.paperBorder)
+  , footer: {
+      height: '0.6in',
+      contents: phantom.callback(function(pageNum, numPages) {
+        if (pageNum === 1) { return; }
+        return "<footer style='display: table; text-align: center; font-size: 8pt; height: 100%; width: 100%;'><p style='display: table-cell; vertical-align: bottom;'>" + args.footerAdditionalHTML + "page " + pageNum + " of " + numPages + "</footer>";
+      })
+    }
   };
 
   setTimeout(function () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -27,7 +27,7 @@ function jadepdf(options) {
       jadeStr += data;
     }
   , function end() {
-      var fn = jade.compile(jadeStr);
+      var fn = jade.compile(jadeStr, options.jadeOptions);
       var html = fn(options.locals);
       this.queue(html);
       this.queue(null);

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,9 @@ function jadepdf(options) {
   options.cssPath = options.cssPath || __dirname + '/../pdf.css';
   options.paperFormat = options.paperFormat || 'A4';
   options.paperOrientation = options.paperOrientation || 'portrait';
-  options.paperBorder = options.paperBorder || '1cm';
+  options.paperBorder = options.paperBorder || {};
+  options.paperBorder = JSON.stringify(options.paperBorder);
+  options.footerAdditionalHTML = options.footerAdditionalHTML || '';
   options.renderDelay = options.renderDelay || 500;
   options.locals = options.locals || {};
   options.jadeOptions = options.jadeOptions || {};
@@ -58,6 +60,7 @@ function jadepdf(options) {
         , options.paperFormat
         , options.paperOrientation
         , options.paperBorder
+        , options.footerAdditionalHTML
         , options.renderDelay
         ];
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,6 +20,7 @@ function jadepdf(options) {
   options.paperBorder = options.paperBorder || '1cm';
   options.renderDelay = options.renderDelay || 500;
   options.locals = options.locals || {};
+  options.jadeOptions = options.jadeOptions || {};
 
   var jadeStr = '';
   var jadeToHtml = through(


### PR DESCRIPTION
I was getting an error when trying to use include statements in my Jade file with relative links. This fix allowed me to pass in the filename which fixes the problem.

See this link for more info:
http://stackoverflow.com/questions/28038630/unable-to-include-relative-path-file-using-jade-template